### PR TITLE
Fix GitHub Issue #7: Add variants of put/putNotNull that take vararg of pairs

### DIFF
--- a/src/main/kotlin/edu/csh/chase/kjson/JsonObject.kt
+++ b/src/main/kotlin/edu/csh/chase/kjson/JsonObject.kt
@@ -180,10 +180,40 @@ class JsonObject() : JsonBase(), Iterable<Map.Entry<String, Any?>> {
      *
      * @param keyValuePair A Pair<String,Any?> of a key to value
      *
-     * @return JsonObect the JsonObject the pair was put into
+     * @return JsonObject the JsonObject the pair was put into
      */
     fun put(keyValuePair: Pair<String, Any?>): JsonObject {
         return put(keyValuePair.first, keyValuePair.second)
+    }
+
+    /**
+     * Puts from a map of key, value Pairs in the given object
+     * This function can be used to chain calls together for simplicity
+     *
+     * @param map A map of key, value - <String, Any?>
+     *
+     * @return JsonObject the JsonObject the list of pairs was put into
+     */
+    fun put(map: Map<String, Any?>): JsonObject {
+        map.forEach { (key, value) ->
+            put(key, value)
+        }
+        return this
+    }
+
+    /**
+     * Puts from a list of key, value Pairs in the given object
+     * This function can be used to chain calls together for simplicity
+     *
+     * @param elementList A list of key, value Pair<String,Any?>
+     *
+     * @return JsonObject the JsonObject the list of pairs was put into
+     */
+    fun put(vararg elementList: Pair<String, Any?>): JsonObject {
+        elementList.filter { it.second.isValidJsonType() }.forEach {
+            put(it)
+        }
+        return this
     }
 
     /**
@@ -209,10 +239,40 @@ class JsonObject() : JsonBase(), Iterable<Map.Entry<String, Any?>> {
      *
      * @param keyValuePair A Pair<String,Any?> of a key to value
      *
-     * @return JsonObect the JsonObject the pair was put into
+     * @return JsonObject the JsonObject the pair was put into
      */
     fun putNotNull(keyValuePair: Pair<String, Any?>): JsonObject {
         return putNotNull(keyValuePair.first, keyValuePair.second)
+    }
+
+    /**
+     * Puts from a map of key, value Pairs in the given object only if the value is not null
+     * This function can be used to chain calls together for simplicity
+     *
+     * @param map A map of key, value - <String, Any?>
+     *
+     * @return JsonObject the JsonObject the list of pairs was put into
+     */
+    fun putNotNull(map: Map<String, Any?>): JsonObject {
+        map.forEach { (key, value) ->
+            putNotNull(key, value)
+        }
+        return this
+    }
+
+    /**
+     * Puts from a list of key, value Pairs in the given object only if the value is not null
+     * This function can be used to chain calls together for simplicity
+     *
+     * @param elementList A list of key, value Pair<String,Any?>
+     *
+     * @return JsonObject the JsonObject the list of pairs was put into
+     */
+    fun putNotNull(vararg elementList: Pair<String, Any?>): JsonObject {
+        elementList.filter { it.second.isValidJsonType() }.forEach {
+            putNotNull(it)
+        }
+        return this
     }
 
     //Getters

--- a/src/test/kotlin/json/JsonObjectTest.kt
+++ b/src/test/kotlin/json/JsonObjectTest.kt
@@ -127,4 +127,83 @@ class JsonObjectTest() {
 
     }
 
+    @Test fun JsonPutTest1() {
+        val obj = JsonObject()
+        assertEquals(0, obj.size)
+
+        try {
+            obj.put("string", "aString")
+            obj.put("int", 10)
+        } catch(invalidValue: JsonException) {
+            assert(false) { "Invalid value added to JsonObject ${invalidValue.message}" }
+        }
+
+        assertEquals(2, obj.size)
+
+        try {
+            obj.put("double",15.0)
+            obj.put("double",Double.NEGATIVE_INFINITY)
+            assert(false) { "An infinite double was added to a JsonObject" }
+        } catch(invalidDouble: JsonException) {
+
+        }
+
+        assertEquals(15.0, obj["double"] as Double, 0.0)
+
+        try {
+            obj.put("invalidType", "key" to "value")
+            assert(false) { "An invalid type was added to a JsonObject" }
+        } catch(invalidType: JsonException) {
+        }
+
+        assertEquals(3, obj.size)
+
+        try {
+            obj.putNotNull("notNull", "ok")
+            obj.putNotNull("null", null)
+        } catch(invalidValue: JsonException) {
+            assert(false) { "Invalid value added to JsonObject ${invalidValue.message}" }
+        }
+
+        assertEquals(4, obj.size) // only the "notNull" key/value should have been added
+    }
+
+    @Test fun JsonPutTest2() {
+        val obj = JsonObject()
+        assertEquals(0, obj.size)
+
+        try {
+            obj.put("string" to "aString", "int" to 10)
+        } catch(invalidValue: JsonException) {
+            assert(false) { "Invalid value added to JsonObject ${invalidValue.message}" }
+        }
+
+        assertEquals(2, obj.size)
+
+        try {
+            obj.put("double" to 15.0, "double" to Double.NEGATIVE_INFINITY)
+            assert(false) { "An infinite double was added to a JsonObject" }
+        } catch(invalidDouble: JsonException) {
+
+        }
+
+        assertEquals(15.0, obj["double"] as Double, 0.0)
+
+        try {
+            obj.put("invalidType", "key" to "value")
+            assert(false) { "An invalid type was added to a JsonObject" }
+        } catch(invalidType: JsonException) {
+        }
+
+        assertEquals(3, obj.size)
+
+        try {
+            obj.putNotNull("notNull" to "ok", "null" to null)
+        } catch(invalidValue: JsonException) {
+            assert(false) { "Invalid value added to JsonObject ${invalidValue.message}" }
+        }
+
+        assertEquals(4, obj.size) // only the "notNull" key/value should have been added
+    }
+
 }


### PR DESCRIPTION
Added put & putNotNull methods that take a map and a vararg of pairs to mirror constructor options